### PR TITLE
passing the env variable IOTA_TANGLE_URL

### DIFF
--- a/day2/docker/launch_docker.sh
+++ b/day2/docker/launch_docker.sh
@@ -4,5 +4,5 @@
 docker run -it --privileged \
     -v ~/diec:/code \
     -e IOTA_TANGLE_URL=${IOTA_TANGLE_URL:-http://your_ec2_url:14265} \
-    -e MICROBIT_PORT=/dev/ttyACM0 \     
+    --env-file=.env \     
     lisaong/rpi-buster-pyota:1.0

--- a/day2/docker/launch_docker.sh
+++ b/day2/docker/launch_docker.sh
@@ -3,5 +3,6 @@
 # https://vsupalov.com/docker-arg-env-variable-guide/
 docker run -it --privileged \
     -v ~/diec:/code \
-    --env-file=.env \
+    -e IOTA_TANGLE_URL=${IOTA_TANGLE_URL:-http://your_ec2_url:14265} \
+    -e MICROBIT_PORT=/dev/ttyACM0 \     
     lisaong/rpi-buster-pyota:1.0


### PR DESCRIPTION
Passing the `IOTA_TANGLE_URL` variable docker if already `export`ed. `.env` is hardcoded now.